### PR TITLE
feat(archive): add ungz method for gzip decompression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,11 @@ xz2 = { version = "0.1", optional = true, features = ["static"] }
 zip = { version = "3", optional = true }
 
 [features]
-archive = ["archive_untar_bzip2", "archive_untar_gzip", "archive_untar_xz", "archive_unzip"]
+archive = ["archive_untar_bzip2", "archive_untar_gzip", "archive_untar_xz", "archive_unzip", "archive_ungz"]
 archive_untar_bzip2 = ["tar", "bzip2"]
 archive_untar_gzip = ["tar", "flate2"]
 archive_untar_xz = ["tar", "xz2"]
+archive_ungz = ["flate2"]
 archive_unzip = ["zip"]
 fslock = ["dep:fslock", "hash"]
 glob = ["globwalk"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,6 +25,7 @@ pub enum XXError {
         feature = "archive_untar_bzip2",
         feature = "archive_untar_xz",
         feature = "archive_unzip",
+        feature = "archive_ungz"
     ))]
     #[error("{0}\n{1}")]
     #[diagnostic(code(xx::archive), url(docsrs))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,11 +15,12 @@ pub mod git;
 pub mod process;
 mod regex;
 
-#[cfg(all(
+#[cfg(any(
     feature = "archive_untar_gzip",
     feature = "archive_untar_bzip2",
     feature = "archive_untar_xz",
     feature = "archive_unzip",
+    feature = "archive_ungz",
 ))]
 pub mod archive;
 


### PR DESCRIPTION
Add `ungz` method to decompress standalone .gz files.

## Changes
- Add `ungz(archive, destination)` function for gzip decompression
- Add `archive_ungz` feature flag 
- Add unit test with temporary file creation/cleanup
- Update Cargo.toml to include new feature

## Usage
```rust
use xx::archive::ungz;
ungz(Path::new("file.gz"), Path::new("file.txt"))?;
```

Complements existing tar.gz, tar.bz2, tar.xz and zip archive support.