### PR TITLE
Update hk to v1.2.2 and fix clippy warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # xx
 
 Just a collection of scripts and helpful things in different projects.
+
+[Documentation](https://docs.rs/xx)

--- a/hk.pkl
+++ b/hk.pkl
@@ -1,5 +1,5 @@
-amends "package://github.com/jdx/hk/releases/download/v0.8.5/hk@0.8.5#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v0.8.5/hk@0.8.5#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.2.2/hk@1.2.2#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.2.2/hk@1.2.2#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
     ["cargo_clippy"] = Builtins.cargo_clippy

--- a/mise.toml
+++ b/mise.toml
@@ -25,5 +25,5 @@ RUST_TEST_THREADS = '1'
 
 [tools]
 "cargo:cargo-llvm-cov" = "latest"
-hk = "latest"
+hk = "1.2.2"
 pkl = "latest"

--- a/src/file.rs
+++ b/src/file.rs
@@ -26,7 +26,7 @@ pub use std::fs::*;
 /// ```
 pub fn open<P: AsRef<Path>>(path: P) -> XXResult<fs::File> {
     let path = path.as_ref();
-    debug!("open: {:?}", path);
+    debug!("open: {path:?}");
     fs::File::open(path).map_err(|err| XXError::FileError(err, path.to_path_buf()))
 }
 
@@ -45,7 +45,7 @@ pub fn open<P: AsRef<Path>>(path: P) -> XXResult<fs::File> {
 /// ```
 pub fn create<P: AsRef<Path>>(path: P) -> XXResult<fs::File> {
     let path = path.as_ref();
-    debug!("create: {:?}", path);
+    debug!("create: {path:?}");
     fs::File::create(path).map_err(|err| XXError::FileError(err, path.to_path_buf()))
 }
 
@@ -110,7 +110,7 @@ pub fn mkdirp<P: AsRef<Path>>(path: P) -> XXResult<()> {
     if path.exists() {
         return Ok(());
     }
-    debug!("mkdirp: {:?}", path);
+    debug!("mkdirp: {path:?}");
     fs::create_dir_all(path).map_err(|err| XXError::FileError(err, path.to_path_buf()))?;
     Ok(())
 }
@@ -127,7 +127,7 @@ pub fn mkdirp<P: AsRef<Path>>(path: P) -> XXResult<()> {
 pub fn mv<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> XXResult<()> {
     let from = from.as_ref();
     let to = to.as_ref();
-    debug!("mv: {:?} -> {:?}", from, to);
+    debug!("mv: {from:?} -> {to:?}");
     mkdirp(to.parent().unwrap())?;
     fs::rename(from, to).map_err(|err| XXError::FileError(err, from.to_path_buf()))?;
     Ok(())
@@ -144,7 +144,7 @@ pub fn mv<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> XXResult<()> {
 pub fn remove_dir_all<P: AsRef<Path>>(path: P) -> XXResult<()> {
     let path = path.as_ref();
     if path.exists() {
-        debug!("remove_dir_all: {:?}", path);
+        debug!("remove_dir_all: {path:?}");
         fs::remove_dir_all(path).map_err(|err| XXError::FileError(err, path.to_path_buf()))?;
     }
     Ok(())

--- a/src/git.rs
+++ b/src/git.rs
@@ -53,7 +53,7 @@ impl Git {
             "--prune",
             "--update-head-ok",
             "origin",
-            &format!("{}:{}", gitref, gitref),
+            &format!("{gitref}:{gitref}"),
         ))?;
         let prev_rev = self.current_sha()?;
         exec(git_cmd!(
@@ -139,11 +139,8 @@ pub fn clone<D: AsRef<Path>>(url: &str, dir: D, clone_options: &CloneOptions) ->
         file::mkdirp(parent)?;
     }
     match get_git_version() {
-        Ok(version) => trace!("git version: {}", version),
-        Err(err) => warn!(
-            "failed to get git version: {:#}\n Git is required to use mise.",
-            err
-        ),
+        Ok(version) => trace!("git version: {version}"),
+        Err(err) => warn!("failed to get git version: {err:#}\n Git is required to use mise."),
     }
 
     let dir_str = dir.to_string_lossy().to_string();

--- a/src/process.rs
+++ b/src/process.rs
@@ -29,7 +29,7 @@ pub fn check_status(status: ExitStatus) -> io::Result<()> {
     } else {
         "terminated by signal".to_string()
     };
-    Err(io::Error::new(io::ErrorKind::Other, msg))
+    Err(io::Error::other(msg))
 }
 
 #[derive(Debug, Default, Clone)]
@@ -77,14 +77,14 @@ impl XXExpression {
     }
 
     pub fn run(&self) -> XXResult<Output> {
-        debug!("$ {}", self);
+        debug!("$ {self}");
         let expr = self.build_expr();
         expr.run()
             .map_err(|err| XXError::ProcessError(err, self.to_string()))
     }
 
     pub fn read(&self) -> XXResult<String> {
-        debug!("$ {}", self);
+        debug!("$ {self}");
         let expr = self.build_expr();
         expr.read()
             .map_err(|err| XXError::ProcessError(err, self.to_string()))


### PR DESCRIPTION
## Summary
- Updated hk version from 0.8.5 to 1.2.2 to resolve pkl configuration parsing errors
- Fixed all clippy linting warnings to ensure clean builds
- Added documentation link to README

## Changes
- **hk.pkl**: Bumped package references from v0.8.5 to v1.2.2
- **mise.toml**: Changed hk version from "latest" to explicit "1.2.2"
- **src/file.rs**: Fixed uninlined format args in debug statements
- **src/git.rs**: Fixed uninlined format args in trace/warn statements  
- **src/process.rs**: Fixed uninlined format args and replaced `io::Error::new` with `io::Error::other`
- **README.md**: Added link to docs.rs/xx documentation

## Test plan
- [x] `mise lint` runs successfully without errors
- [x] All clippy warnings resolved
- [x] hk configuration parses correctly with v1.2.2

🤖 Generated with [Claude Code](https://claude.ai/code)