### PR TITLE
fix: cross-platform doc tests for file and hash operations

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -176,8 +176,11 @@ pub fn mkdirp<P: AsRef<Path>>(path: P) -> XXResult<()> {
 /// * `to` - A path to move the file or directory to
 /// # Example
 /// ```
-/// xx::file::create("/tmp/foo").unwrap();
-/// xx::file::mv("/tmp/foo", "/tmp/bar").unwrap();
+/// # let tmpdir = tempfile::tempdir().unwrap();
+/// # let foo_path = tmpdir.path().join("foo");
+/// # let bar_path = tmpdir.path().join("bar");
+/// xx::file::create(&foo_path).unwrap();
+/// xx::file::mv(&foo_path, &bar_path).unwrap();
 /// ```
 pub fn mv<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> XXResult<()> {
     let from = from.as_ref();

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -104,9 +104,12 @@ where
 /// Returns an error if the checksum does not match
 /// # Example
 /// ```
-/// use std::path::Path;
+/// # let tmpdir = tempfile::tempdir().unwrap();
+/// # let test_path = tmpdir.path().join("test.txt");
+/// # std::fs::write(&test_path, "foobar").unwrap();
 /// use xx::hash::ensure_checksum_sha256;
-/// ensure_checksum_sha256(Path::new("test/data/foo.txt"), "aec070645fe53ee3b3763059376134f058cc337247c978add178b6ccdfb0019f").unwrap();
+/// // SHA256 hash of "foobar"
+/// ensure_checksum_sha256(&test_path, "c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2").unwrap();
 /// ```
 pub fn ensure_checksum_sha256(path: &Path, checksum: &str) -> XXResult<()> {
     let actual = file_hash_sha256(path)?;
@@ -127,9 +130,12 @@ pub fn ensure_checksum_sha256(path: &Path, checksum: &str) -> XXResult<()> {
 /// Returns an error if the checksum does not match
 /// # Example
 /// ```
-/// use std::path::Path;
+/// # let tmpdir = tempfile::tempdir().unwrap();
+/// # let test_path = tmpdir.path().join("test.txt");
+/// # std::fs::write(&test_path, "foobar").unwrap();
 /// use xx::hash::ensure_checksum_sha512;
-/// ensure_checksum_sha512(Path::new("test/data/foo.txt"), "e79b8ad22b34a54be999f4eadde2ee895c208d4b3d83f1954b61255d2556a8b73773c0dc0210aa044ffcca6834839460959cbc9f73d3079262fc8bc935d46262").unwrap();
+/// // SHA512 hash of "foobar"
+/// ensure_checksum_sha512(&test_path, "0a50261ebd1a390fed2bf326f2673c145582a6342d523204973d0219337f81616a8069b012587cf5635f6925f1b56c360230c19b273500ee013e030601bf2425").unwrap();
 /// ```
 pub fn ensure_checksum_sha512(path: &Path, checksum: &str) -> XXResult<()> {
     let actual = file_hash_sha512(path)?;


### PR DESCRIPTION
## Summary

This PR fixes cross-platform compatibility issues with doc tests in the xx library that were causing failures on Windows:

- **file::mv doc test**: Changed from using hardcoded Unix paths (`/tmp/foo`) to using `tempfile::tempdir()` for cross-platform temporary file creation
- **hash::ensure_checksum_* doc tests**: Changed from relying on existing test files (which have platform-specific line endings) to creating test files with predictable content using `std::fs::write()`

## Problem

The original doc tests were failing on Windows because:
1. Unix paths like `/tmp/foo` don't exist on Windows
2. Test files with different line endings (LF vs CRLF) produce different hash checksums on different platforms

## Solution

- Use `tempfile::tempdir()` for platform-agnostic temporary directory creation
- Create test files with known content using `std::fs::write()` which avoids line ending conversion issues
- Use the correct SHA256/SHA512 hashes for the string "foobar" (without line endings)

## Test Results

All doc tests now pass on both Windows and Unix platforms.

🤖 Generated with [Claude Code](https://claude.ai/code)