### PR TITLE
fix(deps): update digest ecosystem crates to 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,7 +268,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -315,6 +324,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "constant_time_eq"
@@ -401,6 +416,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,9 +469,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -521,7 +556,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -827,7 +862,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -886,6 +921,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1313,7 +1357,7 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47bb1e988e6fb779cf720ad431242d3f03167c1b3f2b1aae7f1a94b2495b36ae"
 dependencies = [
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1338,12 +1382,12 @@ dependencies = [
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -1512,7 +1556,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1544,7 +1588,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "hmac",
 ]
 
@@ -1705,7 +1749,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1892,7 +1936,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1949,7 +1993,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2098,7 +2142,18 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -2109,7 +2164,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -2279,7 +2345,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2834,7 +2900,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3334,8 +3400,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sha1",
- "sha2",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
  "strsim",
  "tar",
  "tempfile",
@@ -3484,7 +3550,7 @@ dependencies = [
  "memchr",
  "pbkdf2",
  "ppmd-rust",
- "sha1",
+ "sha1 0.10.6",
  "time",
  "typed-path",
  "zeroize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,15 +23,15 @@ fslock = { version = "0.2", optional = true }
 globwalk = { version = "0.9", optional = true }
 homedir = "0.3"
 log = "0.4"
-md-5 = { version = "0.10", optional = true }
+md-5 = { version = "0.11", optional = true }
 miette = "7"
 regex = "1"
 reqwest = { version = "0.13", optional = true, default-features = false }
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 serde_urlencoded = { version = "0.7", optional = true }
-sha1 = { version = "0.10", optional = true }
-sha2 = { version = "0.10", optional = true }
+sha1 = { version = "0.11", optional = true }
+sha2 = { version = "0.11", optional = true }
 strsim = "0.11"
 tar = { version = "0.4", optional = true }
 thiserror = "2"

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -36,7 +36,11 @@ use crate::file::display_path;
 use crate::{XXError, XXResult, bail, file};
 
 fn hex(bytes: &[u8]) -> String {
-    bytes.iter().map(|b| format!("{b:02x}")).collect()
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        std::fmt::Write::write_fmt(&mut s, format_args!("{b:02x}")).unwrap();
+    }
+    s
 }
 
 /// Calculate the hash of a value

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -27,14 +27,17 @@
 use std::collections::HashMap;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
-use std::io::{Read, Write};
+use std::io::Read;
 use std::path::Path;
 
 use sha2::Digest;
-use sha2::digest::Output;
 
 use crate::file::display_path;
 use crate::{XXError, XXResult, bail, file};
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
 
 /// Calculate the hash of a value
 /// # Arguments
@@ -70,7 +73,7 @@ pub fn file_hash_sha256(path: impl AsRef<Path>) -> XXResult<String> {
     let path = path.as_ref();
     debug!("Calculating SHA256 checksum for {}", display_path(path));
     let h = file_hash::<sha2::Sha256>(path)?;
-    Ok(format!("{h:x}"))
+    Ok(hex(h.as_slice()))
 }
 
 /// Calculate the SHA512 checksum of a file
@@ -90,17 +93,14 @@ pub fn file_hash_sha512(path: impl AsRef<Path>) -> XXResult<String> {
     let path = path.as_ref();
     debug!("Calculating SHA512 checksum for {}", display_path(path));
     let h = file_hash::<sha2::Sha512>(path)?;
-    Ok(format!("{h:x}"))
+    Ok(hex(h.as_slice()))
 }
 
-pub fn file_hash<H>(path: &Path) -> XXResult<Output<H>>
+pub fn file_hash<H>(path: &Path) -> XXResult<sha2::digest::Output<H>>
 where
-    H: Digest + Write,
+    H: Digest,
 {
     let mut file = file::open(path)?;
-    // if let Some(pr) = pr {
-    //     pr.set_length(file.metadata()?.len());
-    // }
     let mut hasher = H::new();
     let mut buf = [0; 32 * 1024];
     loop {
@@ -110,15 +110,8 @@ where
         if n == 0 {
             break;
         }
-        hasher
-            .write_all(&buf[..n])
-            .map_err(|err| XXError::FileError(err, path.to_path_buf()))?;
-        // if let Some(pr) = pr {
-        //     pr.inc(n as u64);
-        // }
+        hasher.update(&buf[..n]);
     }
-    std::io::copy(&mut file, &mut hasher)
-        .map_err(|err| XXError::FileError(err, path.to_path_buf()))?;
     Ok(hasher.finalize())
 }
 
@@ -196,7 +189,7 @@ pub fn parse_shasums(text: &str) -> HashMap<String, String> {
 pub fn sha256(data: &[u8]) -> String {
     let mut hasher = sha2::Sha256::new();
     hasher.update(data);
-    format!("{:x}", hasher.finalize())
+    hex(hasher.finalize().as_slice())
 }
 
 /// Calculate the SHA512 hash of bytes
@@ -209,7 +202,7 @@ pub fn sha256(data: &[u8]) -> String {
 pub fn sha512(data: &[u8]) -> String {
     let mut hasher = sha2::Sha512::new();
     hasher.update(data);
-    format!("{:x}", hasher.finalize())
+    hex(hasher.finalize().as_slice())
 }
 
 // MD5 support (feature-gated)
@@ -240,7 +233,7 @@ pub fn file_hash_md5(path: impl AsRef<Path>) -> XXResult<String> {
         }
         hasher.update(&buf[..n]);
     }
-    Ok(format!("{:x}", hasher.finalize()))
+    Ok(hex(hasher.finalize().as_slice()))
 }
 
 #[cfg(feature = "hash_md5")]
@@ -257,7 +250,7 @@ pub fn md5(data: &[u8]) -> String {
     use md5::Digest;
     let mut hasher = md5::Md5::new();
     hasher.update(data);
-    format!("{:x}", hasher.finalize())
+    hex(hasher.finalize().as_slice())
 }
 
 // SHA1 support (feature-gated)
@@ -288,7 +281,7 @@ pub fn file_hash_sha1(path: impl AsRef<Path>) -> XXResult<String> {
         }
         hasher.update(&buf[..n]);
     }
-    Ok(format!("{:x}", hasher.finalize()))
+    Ok(hex(hasher.finalize().as_slice()))
 }
 
 #[cfg(feature = "hash_sha1")]
@@ -305,7 +298,7 @@ pub fn sha1(data: &[u8]) -> String {
     use sha1::Digest;
     let mut hasher = sha1::Sha1::new();
     hasher.update(data);
-    format!("{:x}", hasher.finalize())
+    hex(hasher.finalize().as_slice())
 }
 
 // Blake3 support (feature-gated)
@@ -367,6 +360,8 @@ pub fn ensure_checksum_blake3(path: &Path, checksum: &str) -> XXResult<()> {
 
 #[cfg(test)]
 mod tests {
+    use std::io::Write;
+
     use super::*;
 
     #[test]


### PR DESCRIPTION
## Summary
- Updates `sha2`, `sha1`, and `md-5` crates from 0.10 to 0.11
- These crates share the `digest` trait crate and must be updated together (each individual Renovate PR fails because of trait incompatibility across digest versions)
- Adapts `src/hash.rs` to the digest 0.11 API: replaces `LowerHex` formatting with manual hex conversion, removes `Write` trait bound from `file_hash`, uses `update()` instead of `write_all()`

Closes #212, closes #213, closes #214

## Test plan
- [x] All 152 tests pass with `--all-features`
- [x] Clippy and fmt checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it upgrades core hashing dependencies and changes checksum formatting/streaming logic, which could subtly alter output or performance if the new `digest` API is misused.
> 
> **Overview**
> Updates the `digest` ecosystem by bumping `sha2`, `sha1`, and `md-5` from `0.10` to `0.11` (and refreshing `Cargo.lock` with the new transitive crates/versions).
> 
> Adapts `src/hash.rs` to the `digest` 0.11 API by removing the `Write`-based hashing path, using `Digest::update()` for file hashing, and replacing `{:x}`-based output with a shared manual hex encoder to keep checksum strings stable across algorithms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51ffe811b0ca954ddc02de93ee085dc8c7dad9d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->