### PR TITLE
chore: bump hk to 1.44.1

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -27,5 +27,5 @@ RUST_TEST_THREADS = '1'
 cargo-binstall = "latest"
 "cargo:cargo-llvm-cov" = "latest"
 "cargo:cargo-msrv" = "latest"
-hk = "1.43.0"
+hk = "1.44.1"
 pkl = "latest"


### PR DESCRIPTION
Bumps hk to 1.44.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates a development tool version pin and does not change runtime or application logic.
> 
> **Overview**
> Updates the `hk` tool pin in `mise.toml` from `1.43.0` to `1.44.1`, affecting the version used by `hk check` in lint/pre-commit/CI tasks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d515ec904930a9c7107374259ae690292cff369e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->