### PR TITLE
fix: support default wasm builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3238,6 +3238,7 @@ dependencies = [
  "filetime",
  "flate2",
  "fslock",
+ "getrandom 0.4.2",
  "globwalk",
  "homedir",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,14 +15,11 @@ rust-version = "1.88"
 [dependencies]
 blake3 = { version = "1", optional = true }
 bzip2 = { version = "0.6", optional = true }
-duct = "1"
 rand = "0.10"
-filetime = "0.2"
 flate2 = { version = "1", optional = true }
 fslock = { version = "0.2", optional = true }
 libc = { version = "0.2", optional = true }
 globwalk = { version = "0.9", optional = true }
-homedir = "0.3"
 log = "0.4"
 md-5 = { version = "0.11", optional = true }
 miette = "7"
@@ -39,6 +36,14 @@ thiserror = "2"
 tokio = { version = "1", optional = true, features = ["full"] }
 xz2 = { version = "0.1", optional = true, features = ["static"] }
 zip = { version = "8", optional = true }
+
+[target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
+duct = "1"
+filetime = "0.2"
+homedir = "0.3"
+
+[target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
+getrandom = { version = "0.4", features = ["wasm_js"] }
 
 [features]
 archive = ["archive_untar_bzip2", "archive_untar_gzip", "archive_untar_xz", "archive_unzip", "archive_ungz", "archive_tar_bzip2", "archive_tar_gzip", "archive_tar_xz", "archive_zip", "archive_gz"]

--- a/mise.toml
+++ b/mise.toml
@@ -3,6 +3,7 @@ tasks.build-release = "cargo build --all --all-features --release"
 tasks.format = "cargo fmt --all"
 tasks.release = "cargo release"
 tasks.clean = "cargo clean"
+tasks.check-wasm = "rustup target add wasm32-unknown-unknown && cargo check --target wasm32-unknown-unknown && cargo check --target wasm32-unknown-unknown --features archive_untar_bzip2,archive_untar_gzip,archive_unzip,archive_ungz,archive_tar_bzip2,archive_tar_gzip,archive_zip,archive_gz,cache,glob,hash_blake3,hash_md5,hash_sha1"
 
 [tasks.lint]
 alias = "l"
@@ -15,7 +16,7 @@ run = "cargo test --all --all-features -- --nocapture"
 env = { RUST_LOG = "xx=trace" }
 
 [tasks.ci]
-depends = ["lint", "test"]
+depends = ["lint", "test", "check-wasm"]
 
 [tasks.pre-commit]
 depends = ["lint", "test"]

--- a/src/env.rs
+++ b/src/env.rs
@@ -34,6 +34,8 @@ use std::env;
 use std::path::PathBuf;
 use std::time::Duration;
 
+use crate::home::home_dir;
+
 /// Check if an environment variable is set to a truthy value
 ///
 /// Truthy values: "1", "true", "yes", "on" (case-insensitive)
@@ -110,7 +112,7 @@ pub fn var_option_bool<K: AsRef<str>>(key: K) -> Option<bool> {
 pub fn var_path<K: AsRef<str>>(key: K) -> Option<PathBuf> {
     env::var(key.as_ref()).ok().map(|val| {
         if let Some(stripped) = val.strip_prefix("~/") {
-            if let Some(home) = homedir::my_home().ok().flatten() {
+            if let Some(home) = home_dir() {
                 home.join(stripped)
             } else {
                 PathBuf::from(val)
@@ -360,7 +362,7 @@ pub fn var_or<K: AsRef<str>>(key: K, default: &str) -> String {
 pub fn var_path_or<K: AsRef<str>>(key: K, default: &str) -> PathBuf {
     var_path(key).unwrap_or_else(|| {
         if let Some(stripped) = default.strip_prefix("~/")
-            && let Some(home) = homedir::my_home().ok().flatten()
+            && let Some(home) = home_dir()
         {
             return home.join(stripped);
         }

--- a/src/file.rs
+++ b/src/file.rs
@@ -61,6 +61,7 @@ use std::path::PathBuf;
 #[cfg(feature = "glob")]
 use globwalk::GlobWalkerBuilder;
 
+use crate::home::home_dir;
 use crate::{XXError, XXResult};
 
 pub use std::fs::*;
@@ -222,6 +223,7 @@ pub fn remove_dir_all<P: AsRef<Path>>(path: P) -> XXResult<()> {
 /// use xx::file::touch_dir;
 /// touch_dir("src").unwrap();
 /// ```
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 pub fn touch_dir<P: AsRef<Path>>(dir: P) -> XXResult<()> {
     let dir = dir.as_ref().to_path_buf();
     trace!("touch {}", dir.display());
@@ -309,8 +311,10 @@ pub fn glob<P: Into<PathBuf>>(input: P) -> XXResult<Vec<PathBuf>> {
 /// display_path("/tmp/foo"); // "/tmp/foo"
 /// ```
 pub fn display_path<P: AsRef<Path>>(path: P) -> String {
-    let home = homedir::my_home().unwrap_or_default();
-    let home = home.unwrap_or("/".into()).to_string_lossy().to_string();
+    let home = home_dir()
+        .unwrap_or("/".into())
+        .to_string_lossy()
+        .to_string();
     let path = path.as_ref();
     match path.starts_with(&home) && home != "/" {
         true => path.to_string_lossy().replacen(&home, "~", 1),
@@ -594,6 +598,7 @@ pub fn read<P: AsRef<Path>>(path: P) -> XXResult<Vec<u8>> {
 /// file::touch_file(&path).unwrap();
 /// assert!(path.exists());
 /// ```
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 pub fn touch_file<P: AsRef<Path>>(path: P) -> XXResult<()> {
     let path = path.as_ref();
     debug!("touch_file: {:?}", path);
@@ -921,6 +926,17 @@ pub fn same_file<P: AsRef<Path>, Q: AsRef<Path>>(path1: P, path2: Q) -> XXResult
             (Ok(c1), Ok(c2)) => Ok(c1 == c2),
             // Canonicalization can fail for other reasons (permissions, etc.)
             // Fall back to path comparison if files exist but can't be canonicalized
+            _ => Ok(path1 == path2),
+        }
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        // Verify files exist first (consistent with Unix behavior).
+        fs::metadata(path1).map_err(|err| XXError::FileError(err, path1.to_path_buf()))?;
+        fs::metadata(path2).map_err(|err| XXError::FileError(err, path2.to_path_buf()))?;
+        match (fs::canonicalize(path1), fs::canonicalize(path2)) {
+            (Ok(c1), Ok(c2)) => Ok(c1 == c2),
             _ => Ok(path1 == path2),
         }
     }

--- a/src/home.rs
+++ b/src/home.rs
@@ -1,0 +1,11 @@
+use std::path::PathBuf;
+
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+pub(crate) fn home_dir() -> Option<PathBuf> {
+    homedir::my_home().ok().flatten()
+}
+
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+pub(crate) fn home_dir() -> Option<PathBuf> {
+    None
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,10 +114,13 @@ pub mod file;
 #[cfg(feature = "fslock")]
 pub mod fslock;
 /// Git repository operations
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 pub mod git;
+mod home;
 /// Platform detection utilities
 pub mod platform;
 /// Process execution utilities
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 pub mod process;
 /// Random generation utilities
 pub mod rand;


### PR DESCRIPTION
## Summary
- gate native-only dependencies and modules for `wasm32-unknown-unknown`
- enable `getrandom`'s wasm JS backend so `rand` compiles on bare wasm
- add a `mise r ci` wasm check to prevent regressions

## Test
- `cargo check --target wasm32-unknown-unknown`
- `mise r ci`

_This PR was generated by Claude Code._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> WASM builds omit git, process, and filetime-based touch APIs from the public surface; native behavior is unchanged but downstream wasm consumers must avoid those symbols.
> 
> **Overview**
> Enables **`xx`** to compile for **`wasm32-unknown-unknown`** by splitting native-only dependencies and gating modules/APIs that cannot run on bare WASM.
> 
> **Cargo** moves `duct`, `filetime`, and `homedir` behind a non-WASM target cfg and adds **`getrandom`** with the **`wasm_js`** feature on WASM so **`rand`** builds. **`mise`** gains a **`check-wasm`** task (default + feature-heavy `cargo check`) wired into **`ci`**.
> 
> **Code** adds internal **`home_dir()`** (real home on native, `None` on WASM) and routes **`env`** / **`file::display_path`** through it. **`git`** and **`process`** are not exported on WASM; **`touch_dir`** / **`touch_file`** are cfg-gated off WASM. **`same_file`** gains a non-Unix/non-Windows canonicalize fallback aligned with the Windows path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 711e1734cca821cc16528efd0213aa31521d38ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WebAssembly (WASM) target compatibility and platform-specific behavior for WASM vs native builds.

* **Chores**
  * Enhanced CI to run WASM-target checks.
  * Reorganized dependencies to separate WASM and non-WASM requirements.

* **Bug Fixes / Improvements**
  * Safer home-directory and path handling across targets.
  * File touch and related operations are disabled on constrained WASM targets to avoid runtime issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->