### PR TITLE
fix: support wasm32-wasip1 builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ tokio = { version = "1", optional = true, features = ["full"] }
 xz2 = { version = "0.1", optional = true, features = ["static"] }
 zip = { version = "8", optional = true }
 
-[target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
 duct = "1"
 filetime = "0.2"
 homedir = "0.3"

--- a/mise.toml
+++ b/mise.toml
@@ -3,7 +3,7 @@ tasks.build-release = "cargo build --all --all-features --release"
 tasks.format = "cargo fmt --all"
 tasks.release = "cargo release"
 tasks.clean = "cargo clean"
-tasks.check-wasm = "rustup target add wasm32-unknown-unknown && cargo check --target wasm32-unknown-unknown && cargo check --target wasm32-unknown-unknown --features archive_untar_bzip2,archive_untar_gzip,archive_unzip,archive_ungz,archive_tar_bzip2,archive_tar_gzip,archive_zip,archive_gz,cache,glob,hash_blake3,hash_md5,hash_sha1"
+tasks.check-wasm = "rustup target add wasm32-unknown-unknown wasm32-wasip1 && cargo check --target wasm32-unknown-unknown && cargo check --target wasm32-unknown-unknown --features archive_untar_bzip2,archive_untar_gzip,archive_unzip,archive_ungz,archive_tar_bzip2,archive_tar_gzip,archive_zip,archive_gz,cache,glob,hash_blake3,hash_md5,hash_sha1 && cargo check --target wasm32-wasip1"
 
 [tasks.lint]
 alias = "l"

--- a/src/file.rs
+++ b/src/file.rs
@@ -223,7 +223,7 @@ pub fn remove_dir_all<P: AsRef<Path>>(path: P) -> XXResult<()> {
 /// use xx::file::touch_dir;
 /// touch_dir("src").unwrap();
 /// ```
-#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+#[cfg(not(target_family = "wasm"))]
 pub fn touch_dir<P: AsRef<Path>>(dir: P) -> XXResult<()> {
     let dir = dir.as_ref().to_path_buf();
     trace!("touch {}", dir.display());
@@ -598,7 +598,7 @@ pub fn read<P: AsRef<Path>>(path: P) -> XXResult<Vec<u8>> {
 /// file::touch_file(&path).unwrap();
 /// assert!(path.exists());
 /// ```
-#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+#[cfg(not(target_family = "wasm"))]
 pub fn touch_file<P: AsRef<Path>>(path: P) -> XXResult<()> {
     let path = path.as_ref();
     debug!("touch_file: {:?}", path);

--- a/src/home.rs
+++ b/src/home.rs
@@ -1,11 +1,11 @@
 use std::path::PathBuf;
 
-#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+#[cfg(not(target_family = "wasm"))]
 pub(crate) fn home_dir() -> Option<PathBuf> {
     homedir::my_home().ok().flatten()
 }
 
-#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+#[cfg(target_family = "wasm")]
 pub(crate) fn home_dir() -> Option<PathBuf> {
     None
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,13 +114,13 @@ pub mod file;
 #[cfg(feature = "fslock")]
 pub mod fslock;
 /// Git repository operations
-#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+#[cfg(not(target_family = "wasm"))]
 pub mod git;
 mod home;
 /// Platform detection utilities
 pub mod platform;
 /// Process execution utilities
-#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+#[cfg(not(target_family = "wasm"))]
 pub mod process;
 /// Random generation utilities
 pub mod rand;


### PR DESCRIPTION
## Summary
- broaden wasm cfg gates so native-only dependencies and APIs are omitted for all wasm targets, including `wasm32-wasip1`
- keep the `getrandom` JS backend override scoped to `wasm32-unknown-unknown`
- add a default `wasm32-wasip1` check to the wasm CI task

## Test
- `cargo fmt`
- `cargo check --target wasm32-unknown-unknown`
- `cargo check --target wasm32-unknown-unknown --features archive_untar_bzip2,archive_untar_gzip,archive_unzip,archive_ungz,archive_tar_bzip2,archive_tar_gzip,archive_zip,archive_gz,cache,glob,hash_blake3,hash_md5,hash_sha1`
- `cargo check --target wasm32-wasip1`
- `cargo test`
- `mise run lint`

_This PR was generated by Claude Code._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cfg-only and CI changes for wasm targets; no native runtime behavior change beyond correctly omitting native APIs on all wasm triples.
> 
> **Overview**
> **Enables `wasm32-wasip1` builds** by treating all wasm targets the same when deciding what to exclude from the crate, instead of only `wasm32-unknown-unknown`.
> 
> Native-only pieces (`duct`, `filetime`, `homedir`, `git`, `process`, `touch_dir` / `touch_file`, and real `home_dir`) are now gated with `#[cfg(not(target_family = "wasm"))]` (and the wasm stub uses `#[cfg(target_family = "wasm")]`). The **`getrandom` `wasm_js` override stays limited** to `wasm32-unknown-unknown` so WASI does not pick up the browser backend.
> 
> **CI:** `mise` `check-wasm` installs `wasm32-wasip1` and runs `cargo check --target wasm32-wasip1` alongside the existing unknown-unknown checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdb4b708cefd775e82beca2ad8c2893c0b52c3da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined and unified WebAssembly build configuration by simplifying platform target detection logic
  * Extended WebAssembly build verification to include support for the wasm32-wasip1 target alongside existing supported platforms
  * Refined conditional compilation rules for platform-specific functionality to improve code maintainability and consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->